### PR TITLE
4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ The default handling scheme is to output brief exception information to the term
 ```python
 from exceptionx import Retry
 
-@Retry(count=3, cycle=1)
+@Retry(sleep=1, count=3)
 def func():
     int('a')
 ```
 
-If an exception is raised in the decorated function, it will attempt to re-execute the decorated function. The default behavior is to retry exceptions of type `Exception` and all its subclasses. Calling `Retry(count=3, cycle=1)` as above means a maximum of 3 attempts will be made, with a 1-second interval between each attempt.
+If an exception is raised in the decorated function, it will attempt to re-execute the decorated function. The default behavior is to retry exceptions of type `Exception` and all its subclasses. Calling `Retry(sleep=1, count=3)` as above means a maximum of 3 attempts will be made, with a 1-second interval between each attempt.
 
 `Retry` can be used in combination with `TryExcept` to retry exceptions first and then handle them if the retries are unsuccessful:
 
@@ -74,7 +74,7 @@ If an exception is raised in the decorated function, it will attempt to re-execu
 from exceptionx import TryExcept, Retry
 
 @TryExcept(ValueError)
-@Retry(count=3, cycle=1)
+@Retry(sleep=1, count=3)
 def func():
     int('a')
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -55,18 +55,18 @@ def func():
 ```python
 from exceptionx import Retry
 
-@Retry(count=3, cycle=1)
+@Retry(sleep=1, count=3)
 def func():
     int('a')
 ```
-若被装饰的函数中引发了异常，会尝试重新执行被装饰的函数，默认重试 `Exception` 及其所有子类的异常。像上面这样调用 `Retry(count=3, cycle=1)` 表示最大执行3次，每次间隔1秒。
+若被装饰的函数中引发了异常，会尝试重新执行被装饰的函数，默认重试 `Exception` 及其所有子类的异常。像上面这样调用 `Retry(sleep=1, count=3)` 表示最大执行3次，每次间隔1秒。
 
 `Retry` 可以配合 `TryExcept` 使用，将先重试异常，若重试无果，则在最后处理异常：
 ```python
 from exceptionx import TryExcept, Retry
 
 @TryExcept(ValueError)
-@Retry(count=3, cycle=1)
+@Retry(sleep=1, count=3)
 def func():
     int('a')
 ```

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='exceptionx',
-    version='4.0',
+    version='4.1',
     author='Unnamed great master',
     author_email='<gqylpy@outlook.com>',
     license='MIT',


### PR DESCRIPTION
1. `TryExcept` and `TryContext` now support handling exceptions based on exception message strings and have added the functionality to negate exception types.
2. Both `@Retry` and `@Retry()` are now supported as valid syntax, as well as `TryExcept`.
3. Fixed an issue: The retry counter in `Retry` incorrectly started from zero. #4
4. Fixed an issue: The `stacklevel` positioning of the logger object was sometimes inaccurate. #5
5. Optimized exception output for `Retry`, adding display for `limit_time` and `event`.
6. Fixed a serious issue in `Retry` where exception information might be "spammed" output.
7. Added type checking for the parameter `etype`.
8. The internal default value for retry events has been changed to `None`.
9. Updated annotations, comments, and documentation files for the above changes.
---
1. `TryExcept` 和 `TryContext` 现在支持按异常消息字符串处理异常，并新增了异常类型取反的功能。
2. 同时支持 `@Retry` 和 `@Retry()` 作为有效语法，亦 `TryExcept`。
3. 修复问题：`Retry` 中重试计数器错误地从零开始。 #4
4. 修复问题：日志记录器对象 `stacklevel` 定位有时不准确。 #5
5. 优化了 `Retry` 的异常输出，增加了对 `limit_time` 和 `event` 显示。
6. 修复了 `Retry` 中可能会 “疯狂输出” 异常信息的严重问题。
7. 添加对参数 `etype` 的类型校验。
8. 重试事件的内部默认值修改为 `None`。
9. 针对以上改动更新注解，注释及自述文件。
