### PR TITLE
4.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[<img alt="LOGO" src="http://gqylpy.com/static/img/favicon.ico" height="21" width="21"/>](http://www.gqylpy.com)
+[<img alt="LOGO" src="https://python.org/favicon.ico" height="21" width="21"/>](http://gqylpy.com)
 [![Release](https://img.shields.io/github/release/gqylpy/exceptionx.svg?style=flat-square")](https://github.com/gqylpy/exceptionx/releases/latest)
 [![Python Versions](https://img.shields.io/pypi/pyversions/exceptionx)](https://pypi.org/project/exceptionx)
 [![License](https://img.shields.io/pypi/l/exceptionx)](https://github.com/gqylpy/exceptionx/blob/master/LICENSE)

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,4 +1,4 @@
-[<img alt="LOGO" src="http://gqylpy.com/static/img/favicon.ico" height="21" width="21"/>](http://www.gqylpy.com)
+[<img alt="LOGO" src="https://python.org/favicon.ico" height="21" width="21"/>](http://gqylpy.com)
 [![Release](https://img.shields.io/github/release/gqylpy/exceptionx.svg?style=flat-square")](https://github.com/gqylpy/exceptionx/releases/latest)
 [![Python Versions](https://img.shields.io/pypi/pyversions/exceptionx)](https://pypi.org/project/exceptionx)
 [![License](https://img.shields.io/pypi/l/exceptionx)](https://github.com/gqylpy/exceptionx/blob/master/LICENSE)

--- a/exceptionx/i exceptionx.py
+++ b/exceptionx/i exceptionx.py
@@ -326,8 +326,8 @@ class Retry(TryExcept):
             sleep = time2second(sleep)
         elif not (isinstance(sleep, (int, float)) and sleep >= 0):
             raise __getattr__('ParameterError')(
-                f'parameter "{x}" must be of type int or float and greater '
-                f'than or equal to 0, not {sleep!r}.'
+                f'parameter "{x}" is expected to be of type int or float and '
+                f'greater than or equal to 0, not {sleep!r}.'
             )
         elif isinstance(sleep, float) and sleep.is_integer():
             sleep = int(sleep)
@@ -346,8 +346,8 @@ class Retry(TryExcept):
             limit_time = time2second(limit_time)
         elif not (isinstance(limit_time, (int, float)) and limit_time > 0):
             raise __getattr__('ParameterError')(
-                'parameter "limit_time" must be of type int or float and '
-                f'greater than or equal to 0, not {limit_time!r}.'
+                'parameter "limit_time" is expected to be of type int or float '
+                f'and greater than or equal to 0, not {limit_time!r}.'
             )
         elif isinstance(limit_time, float) and limit_time.is_integer():
             limit_time = int(limit_time)
@@ -562,12 +562,12 @@ def time2second(unit_time: str, /, *, __pattern__ = re.compile(r'''
         (?:(\d+(?:\.\d+)?)h)?
         (?:(\d+(?:\.\d+)?)m)?
         (?:(\d+(?:\.\d+)?)s?)?
-''', flags=re.X)) -> Union[int, float]:
+''', flags=re.X | re.I)) -> Union[int, float]:
     if unit_time.isdigit():
         return int(unit_time)
 
-    if not (m := __pattern__.fullmatch(unit_time)):
-        raise ValueError(f'unit time "{unit_time}" format is incorrect.')
+    if not (unit_time and (m := __pattern__.fullmatch(unit_time))):
+        raise ValueError(f'unit time {unit_time!r} format is incorrect.')
 
     r = 0
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='exceptionx',
-    version='4.1.2',
+    version='4.1.3',
     author='Unnamed great master',
     author_email='<gqylpy@outlook.com>',
     license='MIT',


### PR DESCRIPTION
1. Fix the issue of `time2second` matching empty strings.
2. Optimize `time2second` regular expression matching to ignore case.
3. Improve the description of two exception messages to make the semantics more accurate.
---
1. 修复 `time2second` 匹配空字符串的问题。
2. 优化 `time2second` 正则匹配时忽略大小写。
3. 改进两个异常描述信息，使语义更准确。
