### PR TITLE
4.1.8

### DIFF
--- a/exceptionx/__init__.py
+++ b/exceptionx/__init__.py
@@ -67,6 +67,7 @@ class HasErrorMethod(Protocol):
 ETypes: TypeAlias = \
     TypeVar('ETypes', Type[Exception], Tuple[Type[Exception], ...])
 
+ELogger: TypeAlias = TypeVar('ELogger', HasWarningMethod, HasErrorMethod, '...')
 ECallback: TypeAlias = TypeVar('ECallback', bound=Callable[..., None])
 
 WrappedClosure: TypeAlias = TypeVar('WrappedClosure', bound=Callable[..., Any])
@@ -103,15 +104,15 @@ def __getattr__(ename: str, /) -> Type[Error]:
 def TryExcept(
         etype:     ETypes,
         /, *,
-        emsg:      Optional[str]            = None,
-        silent:    Optional[bool]           = None,
-        raw:       Optional[bool]           = None,
-        invert:    Optional[bool]           = None,
-        last_tb:   Optional[bool]           = None,
-        logger:    Optional[HasErrorMethod] = None,
-        ereturn:   Optional[Any]            = None,
-        ecallback: Optional[ECallback]      = None,
-        eexit:     Optional[bool]           = None
+        emsg:      Optional[str]       = None,
+        silent:    Optional[bool]      = None,
+        raw:       Optional[bool]      = None,
+        invert:    Optional[bool]      = None,
+        last_tb:   Optional[bool]      = None,
+        logger:    Optional[ELogger]   = None,
+        ereturn:   Optional[Any]       = None,
+        ecallback: Optional[ECallback] = None,
+        eexit:     Optional[bool]      = None
 ) -> WrappedClosure:
     """
     `TryExcept` is a decorator that handles exceptions raised by the function it
@@ -184,7 +185,7 @@ def Retry(
         raw:        Optional[bool]              = None,
         invert:     Optional[bool]              = None,
         last_tb:    Optional[bool]              = None,
-        logger:     Optional[HasWarningMethod]  = None
+        logger:     Optional[ELogger]           = None
 ) -> WrappedClosure:
     """
     `Retry` is a decorator that retries exceptions raised by the function it
@@ -267,14 +268,14 @@ def Retry(
 def TryContext(
         etype:     ETypes,
         /, *,
-        emsg:      Optional[str]            = None,
-        silent:    Optional[bool]           = None,
-        raw:       Optional[bool]           = None,
-        invert:    Optional[bool]           = None,
-        last_tb:   Optional[bool]           = None,
-        logger:    Optional[HasErrorMethod] = None,
-        ecallback: Optional[ECallback]      = None,
-        eexit:     Optional[bool]           = None
+        emsg:      Optional[str]       = None,
+        silent:    Optional[bool]      = None,
+        raw:       Optional[bool]      = None,
+        invert:    Optional[bool]      = None,
+        last_tb:   Optional[bool]      = None,
+        logger:    Optional[ELogger]   = None,
+        ecallback: Optional[ECallback] = None,
+        eexit:     Optional[bool]      = None
 ) -> None:
     """
     `TryContext` is a context manager that handles exceptions raised within the

--- a/exceptionx/i exceptionx.py
+++ b/exceptionx/i exceptionx.py
@@ -508,7 +508,7 @@ def stderr(einfo: str) -> None:
     sys.stderr.write(f'[{now}] {einfo}\n')
 
 
-def get_logger(logger: logging.Logger) -> Callable[[str], None]:
+def get_logger(logger: Optional[ELogger]) -> Callable[[str], None]:
     if logger is None:
         return stderr
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='exceptionx',
-    version='4.1.7',
+    version='4.1.8',
     author='Unnamed great master',
     author_email='<gqylpy@outlook.com>',
     license='MIT',


### PR DESCRIPTION
1. Optimize the type annotation for the `logger` parameter to accommodate a wider range of types.
2. 3.Correct a few other minor type annotation errors.
---
1. 优化参数 `logger` 的类型注解，以适应更广泛的类型。
2. 修正其它少量类型注解错误。